### PR TITLE
feat: integrate remote KEV loader with scheduler

### DIFF
--- a/server/api/internal/refresh-kev.post.ts
+++ b/server/api/internal/refresh-kev.post.ts
@@ -1,0 +1,12 @@
+import { createError, defineEventHandler, getHeader } from 'h3';
+import { refreshKevFromRemote } from '~~/server/plugins/kev-loader';
+
+export default defineEventHandler(async (event) => {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || getHeader(event, 'x-cron-secret') !== secret) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+  }
+
+  const result = await refreshKevFromRemote();
+  return { ok: true, ...result };
+});

--- a/server/lib/constants.ts
+++ b/server/lib/constants.ts
@@ -52,3 +52,33 @@ export const EPSS_BLEND_WEIGHT = 2.5;
  * Minimum SecScore enforced for CVEs listed in the CISA Known Exploited Vulnerabilities catalog.
  */
 export const KEV_MIN_FLOOR = 8.0;
+
+/**
+ * Canonical CISA Known Exploited Vulnerabilities feed endpoint.
+ */
+export const KEV_FEED_URL = 'https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json';
+
+/**
+ * Filesystem path to the compact KEV cache used for quick reloads.
+ */
+export const KEV_COMPACT_PATH = 'server/.cache/kev-compact.json';
+
+/**
+ * Filesystem path to the bundled KEV fallback dataset tracked in git.
+ */
+export const KEV_FALLBACK_PATH = 'server/data/kev.json';
+
+/**
+ * Maximum time in milliseconds to wait for the remote KEV feed.
+ */
+export const KEV_FETCH_TIMEOUT_MS = 8000;
+
+/**
+ * Default interval (in hours) for periodic KEV refreshes.
+ */
+export const KEV_REFRESH_INTERVAL_HOURS = 6;
+
+/**
+ * User agent string attached to outbound KEV HTTP requests.
+ */
+export const USER_AGENT = 'secscore-poc/1 kev-loader';

--- a/server/lib/kev-index.ts
+++ b/server/lib/kev-index.ts
@@ -1,0 +1,182 @@
+import { readFileSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+
+export interface KevCompactEntry {
+  cveId: string
+  dateAdded?: string
+  vendorProject?: string
+  product?: string
+}
+
+export interface KevCompactFile {
+  etag?: string
+  lastModified?: string
+  updatedAt: string
+  items: KevCompactEntry[]
+}
+
+export interface KevMetaValue {
+  dateAdded?: string
+  vendorProject?: string
+  product?: string
+}
+
+export interface KevRuntimeMetadata {
+  etag?: string
+  lastModified?: string
+  updatedAt?: string
+}
+
+const kevSet: Set<string> = new Set<string>();
+const kevMeta: Map<string, KevMetaValue> = new Map<string, KevMetaValue>();
+let currentEtag: string | undefined;
+let currentLastModified: string | undefined;
+let currentUpdatedAt: string | undefined;
+
+interface KevFullFile {
+  vulnerabilities?: unknown
+}
+
+interface KevCompactCandidate {
+  etag?: unknown
+  lastModified?: unknown
+  updatedAt?: unknown
+  items?: unknown
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function toStringOrUndefined(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeCompactEntry(value: unknown): KevCompactEntry | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const cveIdCandidate = toStringOrUndefined(value.cveId ?? value.cveID);
+  if (!cveIdCandidate) {
+    return null;
+  }
+  const entry: KevCompactEntry = { cveId: cveIdCandidate };
+  const dateAdded = toStringOrUndefined(value.dateAdded);
+  if (dateAdded) {
+    entry.dateAdded = dateAdded;
+  }
+  const vendorProject = toStringOrUndefined(value.vendorProject);
+  if (vendorProject) {
+    entry.vendorProject = vendorProject;
+  }
+  const product = toStringOrUndefined(value.product);
+  if (product) {
+    entry.product = product;
+  }
+  return entry;
+}
+
+function normalizeFromVulnerabilities(payload: KevFullFile): KevCompactEntry[] {
+  const raw = Array.isArray(payload.vulnerabilities) ? payload.vulnerabilities : [];
+  const items: KevCompactEntry[] = [];
+  const seen = new Set<string>();
+  for (const candidate of raw) {
+    const entry = normalizeCompactEntry(candidate);
+    if (!entry) {
+      continue;
+    }
+    if (seen.has(entry.cveId)) {
+      continue;
+    }
+    seen.add(entry.cveId);
+    items.push(entry);
+  }
+  return items;
+}
+
+function normalizeFromCompact(payload: KevCompactCandidate): KevCompactFile {
+  const updatedAt = toStringOrUndefined(payload.updatedAt) ?? new Date().toISOString();
+  const itemsRaw = Array.isArray(payload.items) ? payload.items : [];
+  const items: KevCompactEntry[] = [];
+  const seen = new Set<string>();
+  for (const candidate of itemsRaw) {
+    const entry = normalizeCompactEntry(candidate);
+    if (!entry || seen.has(entry.cveId)) {
+      continue;
+    }
+    seen.add(entry.cveId);
+    items.push(entry);
+  }
+  return {
+    etag: toStringOrUndefined(payload.etag),
+    lastModified: toStringOrUndefined(payload.lastModified),
+    updatedAt,
+    items,
+  };
+}
+
+export function buildCompactFromFull(payload: unknown): KevCompactFile {
+  if (isRecord(payload) && 'items' in payload) {
+    return normalizeFromCompact(payload as KevCompactCandidate);
+  }
+  if (isRecord(payload) && 'vulnerabilities' in payload) {
+    const items = normalizeFromVulnerabilities(payload as KevFullFile);
+    return {
+      updatedAt: new Date().toISOString(),
+      items,
+    };
+  }
+  throw new Error('Invalid KEV payload');
+}
+
+export function hydrateRuntime(compact: KevCompactFile): void {
+  kevSet.clear();
+  kevMeta.clear();
+  for (const item of compact.items) {
+    kevSet.add(item.cveId);
+    kevMeta.set(item.cveId, {
+      dateAdded: item.dateAdded,
+      vendorProject: item.vendorProject,
+      product: item.product,
+    });
+  }
+  currentEtag = compact.etag;
+  currentLastModified = compact.lastModified;
+  currentUpdatedAt = compact.updatedAt;
+}
+
+export function getKevSet(): ReadonlySet<string> {
+  return kevSet;
+}
+
+export function getKevMetaMap(): ReadonlyMap<string, KevMetaValue> {
+  return kevMeta;
+}
+
+export function getRuntimeMetadata(): KevRuntimeMetadata {
+  return {
+    etag: currentEtag,
+    lastModified: currentLastModified,
+    updatedAt: currentUpdatedAt,
+  };
+}
+
+export function loadCompactFromDisk(path: string): KevCompactFile | null {
+  try {
+    const fileContents = readFileSync(path, 'utf8');
+    const parsed = JSON.parse(fileContents) as unknown;
+    return buildCompactFromFull(parsed);
+  }
+  catch {
+    return null;
+  }
+}
+
+export async function saveCompactToDisk(path: string, compact: KevCompactFile): Promise<void> {
+  const serialized = JSON.stringify(compact, null, 2);
+  await writeFile(path, `${serialized}\n`, 'utf8');
+}

--- a/server/plugins/kev-loader.ts
+++ b/server/plugins/kev-loader.ts
@@ -1,0 +1,201 @@
+import { mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { defineNitroPlugin } from 'nitropack/runtime';
+import {
+  KEV_COMPACT_PATH,
+  KEV_FALLBACK_PATH,
+  KEV_FEED_URL,
+  KEV_FETCH_TIMEOUT_MS,
+  USER_AGENT,
+} from '~~/server/lib/constants';
+import {
+  buildCompactFromFull,
+  getKevMetaMap,
+  getKevSet,
+  getRuntimeMetadata,
+  hydrateRuntime,
+  loadCompactFromDisk,
+  saveCompactToDisk,
+  type KevMetaValue,
+  type KevCompactFile,
+  type KevRuntimeMetadata,
+} from '~~/server/lib/kev-index';
+
+interface KevStatus {
+  count: number
+  updatedAt?: string
+  etag?: string
+  lastModified?: string
+}
+
+interface KevRefreshResult {
+  changed: boolean
+  count: number
+  updatedAt: string
+}
+
+const cacheFilePath = resolve(process.cwd(), KEV_COMPACT_PATH);
+const fallbackFilePath = resolve(process.cwd(), KEV_FALLBACK_PATH);
+
+function log(level: 'info' | 'warn', msg: string, context?: Record<string, unknown>): void {
+  const payload = {
+    time: new Date().toISOString(),
+    level,
+    msg,
+    ...(context ?? {}),
+  };
+  console.log(JSON.stringify(payload));
+}
+
+async function ensureCacheDirectory(): Promise<void> {
+  await mkdir(dirname(cacheFilePath), { recursive: true });
+}
+
+async function hydrateFromLocalSources(): Promise<void> {
+  let source: 'cache' | 'fallback' | 'empty' = 'empty';
+  let compact = loadCompactFromDisk(cacheFilePath);
+  if (compact) {
+    source = 'cache';
+  }
+  if (!compact) {
+    const fallback = loadCompactFromDisk(fallbackFilePath);
+    if (fallback) {
+      compact = fallback;
+      source = 'fallback';
+      try {
+        await saveCompactToDisk(cacheFilePath, compact);
+      }
+      catch (error) {
+        log('warn', 'kev.cache_write_failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  if (compact) {
+    hydrateRuntime(compact);
+    log('info', 'kev.bootstrap', {
+      source,
+      count: compact.items.length,
+      updatedAt: compact.updatedAt,
+    });
+    return;
+  }
+
+  const empty: KevCompactFile = {
+    updatedAt: new Date().toISOString(),
+    items: [],
+  };
+  hydrateRuntime(empty);
+  log('warn', 'kev.bootstrap_missing', { source });
+}
+
+function buildRequestHeaders(): Headers {
+  const headers = new Headers({
+    'User-Agent': USER_AGENT,
+    'Accept': 'application/json',
+  });
+  const metadata = getRuntimeMetadata();
+  if (metadata.etag) {
+    headers.set('If-None-Match', metadata.etag);
+  }
+  if (metadata.lastModified) {
+    headers.set('If-Modified-Since', metadata.lastModified);
+  }
+  return headers;
+}
+
+function responseHeadersToCompact(base: KevCompactFile, response: Response): KevCompactFile {
+  const etag = response.headers.get('etag') ?? undefined;
+  const lastModified = response.headers.get('last-modified') ?? undefined;
+  return {
+    ...base,
+    etag,
+    lastModified,
+  };
+}
+
+async function fetchWithTimeout(input: string, headers: Headers): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, KEV_FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(input, {
+      headers,
+      signal: controller.signal,
+    });
+    return response;
+  }
+  finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function isInKev(cveId: string): boolean {
+  return getKevSet().has(cveId);
+}
+
+export function getKevMeta(cveId: string): KevMetaValue | undefined {
+  return getKevMetaMap().get(cveId);
+}
+
+export function getKevStatus(): KevStatus {
+  const metadata: KevRuntimeMetadata = getRuntimeMetadata();
+  return {
+    count: getKevSet().size,
+    updatedAt: metadata.updatedAt,
+    etag: metadata.etag,
+    lastModified: metadata.lastModified,
+  };
+}
+
+export async function refreshKevFromRemote(): Promise<KevRefreshResult> {
+  try {
+    const headers = buildRequestHeaders();
+    const response = await fetchWithTimeout(KEV_FEED_URL, headers);
+    if (response.status === 304) {
+      const metadata = getRuntimeMetadata();
+      log('info', 'kev.refresh', {
+        changed: false,
+        status: response.status,
+        count: getKevSet().size,
+      });
+      const updatedAt = metadata.updatedAt ?? new Date().toISOString();
+      return { changed: false, count: getKevSet().size, updatedAt };
+    }
+    if (!response.ok) {
+      throw new Error(`Unexpected response: ${response.status}`);
+    }
+    const payload = (await response.json()) as unknown;
+    const compact = responseHeadersToCompact(buildCompactFromFull(payload), response);
+    const next: KevCompactFile = {
+      ...compact,
+      updatedAt: new Date().toISOString(),
+    };
+    await saveCompactToDisk(cacheFilePath, next);
+    hydrateRuntime(next);
+    log('info', 'kev.refresh', {
+      changed: true,
+      status: response.status,
+      count: next.items.length,
+      updatedAt: next.updatedAt,
+    });
+    return { changed: true, count: next.items.length, updatedAt: next.updatedAt };
+  }
+  catch (error) {
+    log('warn', 'kev.refresh_failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    const metadata = getRuntimeMetadata();
+    const updatedAt = metadata.updatedAt ?? new Date().toISOString();
+    return { changed: false, count: getKevSet().size, updatedAt };
+  }
+}
+
+export default defineNitroPlugin(async () => {
+  await ensureCacheDirectory();
+  await hydrateFromLocalSources();
+  void refreshKevFromRemote();
+});

--- a/server/plugins/kev-scheduler.ts
+++ b/server/plugins/kev-scheduler.ts
@@ -1,0 +1,36 @@
+import { defineNitroPlugin } from 'nitropack/runtime';
+import type { NitroApp } from 'nitropack/types';
+import { KEV_REFRESH_INTERVAL_HOURS } from '~~/server/lib/constants';
+import { refreshKevFromRemote } from '~~/server/plugins/kev-loader';
+
+function parseIntervalHours(): number {
+  const override = process.env.KEV_REFRESH_INTERVAL_HOURS;
+  if (!override) {
+    return KEV_REFRESH_INTERVAL_HOURS;
+  }
+  const parsed = Number.parseFloat(override);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return KEV_REFRESH_INTERVAL_HOURS;
+  }
+  return parsed;
+}
+
+export default defineNitroPlugin((nitroApp: NitroApp) => {
+  if (process.env.DISABLE_KEV_SCHEDULER === '1') {
+    return;
+  }
+  const hours = parseIntervalHours();
+  if (!Number.isFinite(hours) || hours <= 0) {
+    return;
+  }
+  const intervalMs = hours * 60 * 60 * 1000;
+  const timer = setInterval(() => {
+    void refreshKevFromRemote();
+  }, intervalMs);
+  if (typeof timer === 'object' && timer !== null && 'unref' in timer && typeof (timer as { unref?: () => void }).unref === 'function') {
+    (timer as { unref?: () => void }).unref?.();
+  }
+  nitroApp.hooks.hook('close', () => {
+    clearInterval(timer);
+  });
+});

--- a/server/tasks/kev.refresh.ts
+++ b/server/tasks/kev.refresh.ts
@@ -1,0 +1,5 @@
+import { refreshKevFromRemote } from '~~/server/plugins/kev-loader';
+
+export default async (): Promise<void> => {
+  await refreshKevFromRemote();
+};


### PR DESCRIPTION
## ✅ PR Checklist

Please ensure the following before submitting your PR:

- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I’ve tested the changes and confirmed they work as expected
- [ ] I’ve updated any relevant documentation
- [ ] I’ve added tests (if applicable)

## 🔗 Linked Issue

None.

## 📖 Description

- load a compact KEV index at startup using the on-disk cache or bundled fallback data and expose membership/metadata helpers
- perform conditional remote refreshes with persisted ETag/Last-Modified info, on-disk caching, and periodic scheduler + manual task/endpoint hooks
- surface KEV freshness counters through the health endpoint and API responses while cleaning up legacy loader wiring

## 🚨 Breaking Changes

- [ ] Yes
- [x] No

## 🧪 Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code style / formatting
- [ ] 🔨 Refactoring (no functional changes)
- [ ] 🧰 Tooling / CI
- [ ] 📝 Docs update
- [ ] 🧪 Tests
- [ ] 💡 Other (please describe):

## 🧩 Additional Context

None.


------
https://chatgpt.com/codex/tasks/task_e_68d8035bb5b483338f828353b26984e9